### PR TITLE
refactor: *.stringLiteral accept unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Type guards return `boolean` and narrow types without throwing errors. **Safer t
 | `is.boolean(value)` | `value is boolean` | Checks if value is a boolean |
 | `is.array(value)` | `value is T[]` | Checks if value is an array |
 | `is.nonEmptyArray(value)` | `value is [T, ...T[]]` | Checks if value is a non-empty array |
-| `is.stringLiteral(value, literals)` | `value is U[]` | Checks if value is a string literal |
+| `is.stringLiteral(value, literals)` | `value is T[number]` | Checks if value is a member of string literals array |
 | `is.object(value)` | `value is T` | Checks if value is a plain object |
 
 ### Type Assertions (`assert.*`)
@@ -103,7 +103,7 @@ Assertions throw errors for invalid types and narrow types in the same scope. **
 | `assert.boolean(value, message?)` | `asserts value is boolean` | Throws if value is not a boolean |
 | `assert.array(value, message?)` | `asserts value is T[]` | Throws if value is not an array |
 | `assert.nonEmptyArray(value, message?)` | `asserts value is [T, ...T[]]` | Throws if value is not a non-empty array |
-| `assert.stringLiteral(value, literals, message?)` | `value is U[]` | Throws if value is a string literal |
+| `assert.stringLiteral(value, literals, message?)` | `value is T[number]` | Throws if value is not a member of provided string literals array |
 | `assert.object(value, message?)` | `asserts value is T` | Throws if value is not a plain object |
 | `assert.fromPredicate(predicate, message?)` | `(value, message?) => asserts value is T` | Creates custom assertion from predicate |
 
@@ -219,7 +219,7 @@ const strings = mixedArray.filter(isString) // TypeScript knows these are string
 
 ## 📊 Bundle Size
 
-- **Size**: 602 B (minified + brotli)
+- **Size**: 686 B (minified + brotli)
 - **Dependencies**: 0
 - **Tree-shakeable**: ✅ (import individual functions)
 - **ESM + CJS**: ✅

--- a/src/assert/collections.test.ts
+++ b/src/assert/collections.test.ts
@@ -133,25 +133,25 @@ describe('assert/collections', () => {
   describe('assertStringLiteral', () => {
     test('should not throw when value is in allowed literals', () => {
       expect(() =>
-        assertStringLiteral('a' as 'a' | 'b', ['a', 'b'], 'Invalid literal'),
+        assertStringLiteral('a', ['a', 'b'], 'Invalid literal'),
       ).not.toThrow()
       expect(() =>
-        assertStringLiteral('b' as 'a' | 'b', ['a', 'b'], 'Invalid literal'),
+        assertStringLiteral('b', ['a', 'b'], 'Invalid literal'),
       ).not.toThrow()
     })
 
     test('should throw when value is not in allowed literals', () => {
       expect(() =>
-        assertStringLiteral('c' as 'a' | 'b', ['a', 'b'], 'Invalid literal'),
+        assertStringLiteral('c', ['a', 'b'], 'Invalid literal'),
       ).toThrow('Invalid literal')
       expect(() =>
-        assertStringLiteral('abc' as 'a' | 'b', ['a', 'b'], 'Invalid literal'),
+        assertStringLiteral('abc', ['a', 'b'], 'Invalid literal'),
       ).toThrow('Invalid literal')
     })
 
     test('should be case-sensitive', () => {
       expect(() =>
-        assertStringLiteral('Foo' as 'foo', ['foo'], 'Invalid literal'),
+        assertStringLiteral('Foo', ['foo'], 'Invalid literal'),
       ).toThrow('Invalid literal')
       expect(() =>
         assertStringLiteral('foo', ['foo'], 'Invalid literal'),
@@ -159,9 +159,16 @@ describe('assert/collections', () => {
     })
 
     test('should error with correct defualt error message', () => {
-      expect(() =>
-        assertStringLiteral('d' as 'a' | 'b' | 'c', ['a', 'b', 'c']),
-      ).toThrow(`Expected one of folowing values: a, b, c.`)
+      expect(() => assertStringLiteral('d', ['a', 'b', 'c'])).toThrow(
+        `Expected one of folowing values: a, b, c.`,
+      )
+    })
+
+    test('should narrow type to provided literal union', () => {
+      const value = 'a' as unknown
+      expectTypeOf(value).toEqualTypeOf<unknown>()
+      assertStringLiteral(value, ['a', 'b'], 'Invalid literal')
+      expectTypeOf(value).toEqualTypeOf<'a' | 'b'>()
     })
   })
 

--- a/src/assert/collections.ts
+++ b/src/assert/collections.ts
@@ -23,15 +23,16 @@ export function assertNonEmptyArray<T = unknown>(
 /**
  * Assertion that narrows a value to string literal
  */
-export function assertStringLiteral<T extends string, U extends T>(
-  value: T,
-  literals: U[],
+export function assertStringLiteral<const T extends readonly string[]>(
+  value: unknown,
+  literals: T,
   message?: string,
-): asserts value is U {
-  if (!(literals as T[]).includes(value))
+): asserts value is T[number] {
+  if (typeof value !== 'string' || !literals.includes(value)) {
     raiseAssertError(
       message ?? `Expected one of folowing values: ${literals.join(', ')}.`,
     )
+  }
 }
 
 /**

--- a/src/is/collections.test.ts
+++ b/src/is/collections.test.ts
@@ -105,8 +105,19 @@ describe('collections', () => {
       expect(isStringLiteral('any', [])).toBe(false)
     })
 
+    test('should return false for any non-string value', () => {
+      const literals = ['a', 'b'] as const
+      expect(isStringLiteral(false, literals)).toBe(false)
+      expect(isStringLiteral([], literals)).toBe(false)
+      expect(isStringLiteral({}, literals)).toBe(false)
+      expect(isStringLiteral(1, literals)).toBe(false)
+      expect(isStringLiteral(true, literals)).toBe(false)
+      expect(isStringLiteral(null, literals)).toBe(false)
+      expect(isStringLiteral(undefined, literals)).toBe(false)
+    })
+
     test('should narrow type to provided literal union', () => {
-      const value = 'a' as 'a' | 'b' | 'c'
+      const value = 'a' as unknown
 
       if (isStringLiteral(value, ['a', 'b'])) {
         expectTypeOf(value).toEqualTypeOf<'a' | 'b'>()

--- a/src/is/collections.ts
+++ b/src/is/collections.ts
@@ -17,11 +17,11 @@ export function isNonEmptyArray<T = unknown>(
 /**
  * Type guard that narrows a value to string literal
  */
-export function isStringLiteral<T extends string, U extends T>(
-  value: T,
-  literals: U[],
-): value is U {
-  return (literals as T[]).includes(value)
+export function isStringLiteral<const T extends readonly string[]>(
+  value: unknown,
+  literals: T,
+): value is T[number] {
+  return typeof value === 'string' && literals.includes(value)
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `is.assertStringLiteral` and `is.isStringLiteral` to accept `unknown` and infer from `readonly string[]`, with runtime string checks; adjusts tests and README, and updates bundle size.
> 
> - **Core**:
>   - `src/assert/collections.ts`:`assertStringLiteral` now accepts `unknown` and `const T extends readonly string[]`; asserts `value is T[number]` with a string-type check before membership.
>   - `src/is/collections.ts`:`isStringLiteral` now accepts `unknown` and `const T extends readonly string[]`; returns `value is T[number]` and validates `typeof value === 'string'`.
> - **Tests**:
>   - `src/assert/collections.test.ts`: remove literal casts, add type-narrowing test to `T[number]`, and verify default error message.
>   - `src/is/collections.test.ts`: remove literal casts, add cases for non-string values, and confirm narrowing to `T[number]`.
> - **Docs**:
>   - `README.md`: update function signatures/return types in tables to `T[number]`; adjust bundle size to `686 B`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daaa56d94f74c8c5a6fa804a73ff6d9c00ffbab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->