### PR TITLE
fix: typed collection argument in onOf guards

### DIFF
--- a/src/assert/collections.test.ts
+++ b/src/assert/collections.test.ts
@@ -189,19 +189,21 @@ describe('assert/collections', () => {
     })
 
     test('should not throw when value is in collection (mixed types)', () => {
+      type Literal = 'a' | 1 | true | null
       const collection = ['a', 1, true, null] as const
-      expect(() => assertOneOf('a', collection)).not.toThrow()
-      expect(() => assertOneOf(1, collection)).not.toThrow()
-      expect(() => assertOneOf(true, collection)).not.toThrow()
-      expect(() => assertOneOf(null, collection)).not.toThrow()
+      expect(() => assertOneOf('a' as Literal, collection)).not.toThrow()
+      expect(() => assertOneOf(1 as Literal, collection)).not.toThrow()
+      expect(() => assertOneOf(true as Literal, collection)).not.toThrow()
+      expect(() => assertOneOf(null as Literal, collection)).not.toThrow()
     })
 
     test('should not throw when value is in collection (objects)', () => {
+      type Literal = { a: number } | { b: number }
       const obj1 = { a: 1 }
       const obj2 = { b: 2 }
       const collection = [obj1, obj2] as const
-      expect(() => assertOneOf(obj1, collection)).not.toThrow()
-      expect(() => assertOneOf(obj2, collection)).not.toThrow()
+      expect(() => assertOneOf(obj1 as Literal, collection)).not.toThrow()
+      expect(() => assertOneOf(obj2 as Literal, collection)).not.toThrow()
     })
 
     test('should not throw when value is in collection (arrays)', () => {
@@ -250,29 +252,39 @@ describe('assert/collections', () => {
     })
 
     test('should handle null and undefined correctly', () => {
+      type LiteralWithNull = 'a' | null | 'b'
       const collectionWithNull = ['a', null, 'b'] as const
-      expect(() => assertOneOf(null, collectionWithNull)).not.toThrow()
-      expect(() => assertOneOf(undefined, collectionWithNull)).toThrow(
-        'Expected one of folowing values: a, , b.',
-      )
+      expect(() =>
+        assertOneOf(null as LiteralWithNull, collectionWithNull),
+      ).not.toThrow()
+      expect(() =>
+        assertOneOf(
+          undefined as unknown as LiteralWithNull,
+          collectionWithNull,
+        ),
+      ).toThrow('Expected one of folowing values: a, , b.')
 
+      type LiteralWithUndefined = 'a' | undefined | 'b'
       const collectionWithUndefined = ['a', undefined, 'b'] as const
       expect(() =>
-        assertOneOf(undefined, collectionWithUndefined),
+        assertOneOf(undefined as LiteralWithUndefined, collectionWithUndefined),
       ).not.toThrow()
-      expect(() => assertOneOf(null, collectionWithUndefined)).toThrow(
-        'Expected one of folowing values: a, , b.',
-      )
+      expect(() =>
+        assertOneOf(
+          null as unknown as LiteralWithUndefined,
+          collectionWithUndefined,
+        ),
+      ).toThrow('Expected one of folowing values: a, , b.')
     })
 
     test('should handle boolean values correctly', () => {
       const collection = [true, false] as const
       expect(() => assertOneOf(true, collection)).not.toThrow()
       expect(() => assertOneOf(false, collection)).not.toThrow()
-      expect(() => assertOneOf(1, collection)).toThrow(
+      expect(() => assertOneOf(1 as unknown as boolean, collection)).toThrow(
         'Expected one of folowing values: true, false.',
       )
-      expect(() => assertOneOf(0, collection)).toThrow(
+      expect(() => assertOneOf(0 as unknown as boolean, collection)).toThrow(
         'Expected one of folowing values: true, false.',
       )
     })
@@ -310,12 +322,17 @@ describe('assert/collections', () => {
     })
 
     test('should throw with custom message', () => {
+      type Literal = 'a' | 'b' | 'c'
       const collection = ['a', 'b', 'c'] as const
       expect(() =>
         assertOneOf('d', collection, 'Value must be one of allowed values'),
       ).toThrow('Value must be one of allowed values')
       expect(() =>
-        assertOneOf(1, collection, 'Invalid value provided'),
+        assertOneOf(
+          1 as unknown as Literal,
+          collection,
+          'Invalid value provided',
+        ),
       ).toThrow('Invalid value provided')
     })
 

--- a/src/assert/collections.ts
+++ b/src/assert/collections.ts
@@ -39,11 +39,11 @@ export function assertStringLiteral<const T extends readonly string[]>(
 /**
  * Assertion that narrows the given value to the union of values from the provided collection.
  */
-export function assertOneOf<const T extends readonly unknown[]>(
-  value: unknown,
-  collection: T,
+export function assertOneOf<T, const U extends readonly T[]>(
+  value: T,
+  collection: U,
   message?: string,
-): asserts value is T[number] {
+): asserts value is U[number] {
   if (!collection.includes(value)) {
     raiseAssertError(
       message ?? `Expected one of folowing values: ${collection.join(', ')}.`,

--- a/src/is/collections.test.ts
+++ b/src/is/collections.test.ts
@@ -131,7 +131,7 @@ describe('collections', () => {
   describe('isOneOf', () => {
     test('should return true when value is in collection (strings)', () => {
       const collection = ['a', 'b', 'c'] as const
-      expect(isOneOf('a', collection)).toBe(true)
+      expect(isOneOf('a', ['a', 'd'])).toBe(true)
       expect(isOneOf('b', collection)).toBe(true)
       expect(isOneOf('c', collection)).toBe(true)
     })
@@ -144,19 +144,22 @@ describe('collections', () => {
     })
 
     test('should return true when value is in collection (mixed types)', () => {
+      type Literal = 'a' | 1 | true | null
       const collection = ['a', 1, true, null] as const
-      expect(isOneOf('a', collection)).toBe(true)
-      expect(isOneOf(1, collection)).toBe(true)
-      expect(isOneOf(true, collection)).toBe(true)
-      expect(isOneOf(null, collection)).toBe(true)
+
+      expect(isOneOf('a' as Literal, collection)).toBe(true)
+      expect(isOneOf(1 as Literal, collection)).toBe(true)
+      expect(isOneOf(true as Literal, collection)).toBe(true)
+      expect(isOneOf(null as Literal, collection)).toBe(true)
     })
 
     test('should return true when value is in collection (objects)', () => {
+      type Literal = { a: number } | { b: number }
       const obj1 = { a: 1 }
       const obj2 = { b: 2 }
       const collection = [obj1, obj2] as const
-      expect(isOneOf(obj1, collection)).toBe(true)
-      expect(isOneOf(obj2, collection)).toBe(true)
+      expect(isOneOf(obj1 as Literal, collection)).toBe(true)
+      expect(isOneOf(obj2 as Literal, collection)).toBe(true)
     })
 
     test('should return true when value is in collection (arrays)', () => {
@@ -189,21 +192,32 @@ describe('collections', () => {
     })
 
     test('should handle null and undefined correctly', () => {
+      type LiteralWithNull = 'a' | null | 'b'
       const collectionWithNull = ['a', null, 'b'] as const
-      expect(isOneOf(null, collectionWithNull)).toBe(true)
-      expect(isOneOf(undefined, collectionWithNull)).toBe(false)
+      expect(isOneOf(null as LiteralWithNull, collectionWithNull)).toBe(true)
+      expect(
+        isOneOf(undefined as unknown as LiteralWithNull, collectionWithNull),
+      ).toBe(false)
 
+      type LiteralWithUndefined = 'a' | undefined | 'b'
       const collectionWithUndefined = ['a', undefined, 'b'] as const
-      expect(isOneOf(undefined, collectionWithUndefined)).toBe(true)
-      expect(isOneOf(null, collectionWithUndefined)).toBe(false)
+      expect(
+        isOneOf(undefined as LiteralWithUndefined, collectionWithUndefined),
+      ).toBe(true)
+      expect(
+        isOneOf(
+          null as unknown as LiteralWithUndefined,
+          collectionWithUndefined,
+        ),
+      ).toBe(false)
     })
 
     test('should handle boolean values correctly', () => {
       const collection = [true, false] as const
       expect(isOneOf(true, collection)).toBe(true)
       expect(isOneOf(false, collection)).toBe(true)
-      expect(isOneOf(1, collection)).toBe(false)
-      expect(isOneOf(0, collection)).toBe(false)
+      expect(isOneOf(1 as unknown as boolean, collection)).toBe(false)
+      expect(isOneOf(0 as unknown as boolean, collection)).toBe(false)
     })
 
     test('should handle number values correctly', () => {

--- a/src/is/collections.ts
+++ b/src/is/collections.ts
@@ -28,11 +28,11 @@ export function isStringLiteral<const T extends readonly string[]>(
 /**
  * Type guard that narrows the given value to the union of values from the provided collection.
  */
-export function isOneOf<const T extends readonly unknown[]>(
-  value: unknown,
-  collection: T,
-): value is T[number] {
-  return collection.includes(value)
+export function isOneOf<T, const U extends readonly T[]>(
+  value: T,
+  collection: U,
+): value is U[number] {
+  return collection.includes(value as U[number])
 }
 
 /**


### PR DESCRIPTION
The `collection` argument of `isOneOf` and `assertOneOf` functions now infer type from `value`, so typescript now suggest only valid values.

This is how isStringLiteral works in version 1.1.0.