### PR TITLE
feat: `is.propertyOf`

### DIFF
--- a/.changeset/legal-keys-brush.md
+++ b/.changeset/legal-keys-brush.md
@@ -1,0 +1,7 @@
+---
+"narrowland": minor
+---
+
+Add `is.propertyOf` higher-order guard to narrow individual object properties via any predicate.
+
+Use it to enforce per-property constraints while keeping the rest of the shape intact, e.g. `const hasStringName = is.propertyOf('name', is.string)` now guarantees that name exists and is a string whenever the guard passes.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Type guards return `boolean` and narrow types without throwing errors. **Safer t
 | `is.stringLiteral(value, literals)` ⚠️ | `value is T[number]` | Checks if value is a member of string literals array (deprecated: use `is.oneOf` instead, will be removed in v2.0.0) |
 | `is.oneOf(value, collection)` | `value is T[number]` | Checks if value is a member of the provided collection (works with any type) |
 | `is.object(value)` | `value is T` | Checks if value is a plain object |
+| `is.propertyOf(key, predicate)` | `obj is T & { [P in K]-?: U }` | Checks that the selected property satisfies the provided predicate and makes it required |
 
 ### Type Assertions (`assert.*`)
 
@@ -232,6 +233,32 @@ const values = [new Date(), '2023-01-01', new Date('2024-01-01'), null, 42]
 const dates = values.filter((v) => isInstanceOf(v, Date)) // TypeScript knows `dates` is Date[]
 ```
 
+### Property Guards - Filter Objects by Required Keys
+
+```typescript
+import { isDefined, isPropertyOf } from 'narrowland'
+
+type User = {
+  id: string
+  email?: string | null
+}
+
+const users: User[] = [
+  { id: '1', email: 'one@example.com' },
+  { id: '2', email: null },
+  { id: '3' },
+]
+
+const hasEmail = isPropertyOf('email', isDefined)
+
+const contactableUsers = users.filter(hasEmail)
+// ?^ contactableUsers is typed as PropNarrow<User, "email", {}>[]
+contactableUsers.forEach((user) => {
+  user.email.toLowerCase()
+  // ?^ user.email is typed as string
+})
+```
+
 ### ArrayOf - Array Type Narrowing
 
 ```typescript
@@ -275,7 +302,7 @@ if (isOneOf(value, allowedValues)) {
 
 ## 📊 Bundle Size
 
-- **Size**: 851 B (minified + brotli)
+- **Size**: 862 B (minified + brotli)
 - **Dependencies**: 0
 - **Tree-shakeable**: ✅ (import individual functions)
 - **ESM + CJS**: ✅

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export {
   isNumber,
   isObject,
   isOneOf,
+  isPropertyOf,
   isString,
   isStringLiteral,
   isSymbol,

--- a/src/is/collections.test.ts
+++ b/src/is/collections.test.ts
@@ -618,6 +618,18 @@ describe('is/collections', () => {
         }
       })
 
+      test('should narrow property type to boolean', () => {
+        type Item = { name: string; isInStock?: unknown }
+        const item: Item = { name: 'item' }
+        const isInStock = isPropertyOf('isInStock', isBoolean)
+
+        if (isInStock(item)) {
+          expectTypeOf(item.isInStock).toEqualTypeOf<boolean>()
+          expect(item.name).toBeDefined()
+          expect(item.isInStock).not.toBeDefined()
+        }
+      })
+
       test('should narrow property type to non-empty string', () => {
         type Item = { title?: string | null }
         const item: Item = { title: 'Hello' }

--- a/src/is/collections.ts
+++ b/src/is/collections.ts
@@ -53,3 +53,19 @@ export function isObject<T extends object = object>(
 ): value is T {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
+
+type PropNarrow<T, K extends PropertyKey, U> = T & {
+  [P in K]-?: Extract<(T & Record<K, unknown>)[P], U>
+}
+
+/**
+ * Type guard that narrow the given property of object to the provided type predicate.
+ */
+export function isPropertyOf<K extends PropertyKey, U>(
+  key: K,
+  predicate: (value: unknown) => value is U,
+) {
+  return <T extends Partial<Record<K, unknown>>>(
+    obj: T,
+  ): obj is PropNarrow<T, K, U> => predicate(obj[key])
+}

--- a/src/is/collections.ts
+++ b/src/is/collections.ts
@@ -54,8 +54,12 @@ export function isObject<T extends object = object>(
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/**
+ * Narrows property K of type T to type U, making it required.
+ * Preserves all other properties from T.
+ */
 type PropNarrow<T, K extends PropertyKey, U> = T & {
-  [P in K]-?: Extract<(T & Record<K, unknown>)[P], U>
+  [P in K]: U
 }
 
 /**

--- a/src/is/index.ts
+++ b/src/is/index.ts
@@ -4,6 +4,7 @@ import {
   isNonEmptyArray,
   isObject,
   isOneOf,
+  isPropertyOf,
   isStringLiteral,
 } from './collections'
 import { isDefined, isFalsy, isNotNull, isTruthy } from './existence'
@@ -38,6 +39,7 @@ export const is = {
   oneOf: isOneOf,
   object: isObject,
   instanceof: isInstanceOf,
+  propertyOf: isPropertyOf,
 } as const
 
 export {
@@ -58,4 +60,5 @@ export {
   isNumber,
   isString,
   isOneOf,
+  isPropertyOf,
 }


### PR DESCRIPTION
Add `is.propertyOf` higher-order guard to narrow individual object properties via any predicate.

Use it to enforce per-property constraints while keeping the rest of the shape intact, e.g. `const hasStringName = is.propertyOf('name', is.string)` now guarantees that name exists and is a string whenever the guard passes.