### PR TITLE
fix(lint): drop redundant type assertions flagged by oxlint 1.73

### DIFF
--- a/.changeset/drop-redundant-assertions.md
+++ b/.changeset/drop-redundant-assertions.md
@@ -1,0 +1,7 @@
+---
+"narrowland": patch
+---
+
+Drop redundant type assertions flagged by oxlint 1.73.
+
+Internal cleanup in `ensure`, `ensureOneOf`, `ensureKeyOf`, and `isOneOf`. Runtime output and public type signatures are unchanged — the compiler now verifies the narrowing instead of a blind cast.

--- a/src/assert/collections.test.ts
+++ b/src/assert/collections.test.ts
@@ -401,10 +401,20 @@ describe('assert/collections', () => {
     test('should not throw when value is in collection (mixed types)', () => {
       type Literal = 'a' | 1 | true | null
       const collection = ['a', 1, true, null] as const
-      expect(() => assertOneOf('a' as Literal, collection)).not.toThrow()
-      expect(() => assertOneOf(1 as Literal, collection)).not.toThrow()
-      expect(() => assertOneOf(true as Literal, collection)).not.toThrow()
-      expect(() => assertOneOf(null as Literal, collection)).not.toThrow()
+      // Pin `T` to the collection's element union explicitly; inferring it from
+      // a narrow literal value would fail the `U extends readonly T[]` constraint.
+      expect(() =>
+        assertOneOf<Literal, typeof collection>('a', collection),
+      ).not.toThrow()
+      expect(() =>
+        assertOneOf<Literal, typeof collection>(1, collection),
+      ).not.toThrow()
+      expect(() =>
+        assertOneOf<Literal, typeof collection>(true, collection),
+      ).not.toThrow()
+      expect(() =>
+        assertOneOf<Literal, typeof collection>(null, collection),
+      ).not.toThrow()
     })
 
     test('should not throw when value is in collection (objects)', () => {

--- a/src/ensure/collections.test.ts
+++ b/src/ensure/collections.test.ts
@@ -356,10 +356,16 @@ describe('ensure/collections', () => {
     test('should return the value when in collection (mixed types)', () => {
       type Literal = 'a' | 1 | true | null
       const collection = ['a', 1, true, null] as const
-      expect(ensureOneOf('a' as Literal, collection)).toBe('a')
-      expect(ensureOneOf(1 as Literal, collection)).toBe(1)
-      expect(ensureOneOf(true as Literal, collection)).toBe(true)
-      expect(ensureOneOf(null as Literal, collection)).toBe(null)
+      // Pin `T` to the collection's element union explicitly; inferring it from
+      // a narrow literal value would fail the `U extends readonly T[]` constraint.
+      expect(ensureOneOf<Literal, typeof collection>('a', collection)).toBe('a')
+      expect(ensureOneOf<Literal, typeof collection>(1, collection)).toBe(1)
+      expect(ensureOneOf<Literal, typeof collection>(true, collection)).toBe(
+        true,
+      )
+      expect(ensureOneOf<Literal, typeof collection>(null, collection)).toBe(
+        null,
+      )
     })
 
     test('should return the value when in collection (objects)', () => {

--- a/src/ensure/collections.ts
+++ b/src/ensure/collections.ts
@@ -60,7 +60,7 @@ export function ensureOneOf<T, const U extends readonly T[]>(
       message ?? `Expected one of following values: ${collection.join(', ')}.`,
     )
   }
-  return value as U[number]
+  return value
 }
 
 /**
@@ -89,5 +89,5 @@ export function ensureKeyOf<
         `Expected one of following values: ${Object.keys(record).join(', ')}`,
     )
   }
-  return value as T & keyof U
+  return value
 }

--- a/src/errors/ensure.ts
+++ b/src/errors/ensure.ts
@@ -10,5 +10,5 @@ export function ensure<T>(
   if (value === null || value === undefined) {
     raiseEnsureError(message)
   }
-  return value as NonNullable<T>
+  return value
 }

--- a/src/is/collections.test.ts
+++ b/src/is/collections.test.ts
@@ -241,17 +241,17 @@ describe('is/collections', () => {
 
   describe('isStringLiteral', () => {
     test('should return true when value is in allowed literals', () => {
-      expect(isStringLiteral('a' as 'a' | 'b', ['a', 'b'])).toBe(true)
-      expect(isStringLiteral('b' as 'a' | 'b', ['a', 'b'])).toBe(true)
+      expect(isStringLiteral('a', ['a', 'b'])).toBe(true)
+      expect(isStringLiteral('b', ['a', 'b'])).toBe(true)
     })
 
     test('should return false when value is not in allowed literals', () => {
-      expect(isStringLiteral('c' as 'a' | 'b', ['a', 'b'])).toBe(false)
-      expect(isStringLiteral('ab' as 'a' | 'b', ['a', 'b'])).toBe(false)
+      expect(isStringLiteral('c', ['a', 'b'])).toBe(false)
+      expect(isStringLiteral('ab', ['a', 'b'])).toBe(false)
     })
 
     test('should be case-sensitive', () => {
-      expect(isStringLiteral('Foo' as 'foo', ['foo'])).toBe(false)
+      expect(isStringLiteral('Foo', ['foo'])).toBe(false)
       expect(isStringLiteral('foo', ['foo'])).toBe(true)
     })
 
@@ -300,10 +300,12 @@ describe('is/collections', () => {
       type Literal = 'a' | 1 | true | null
       const collection = ['a', 1, true, null] as const
 
-      expect(isOneOf('a' as Literal, collection)).toBe(true)
-      expect(isOneOf(1 as Literal, collection)).toBe(true)
-      expect(isOneOf(true as Literal, collection)).toBe(true)
-      expect(isOneOf(null as Literal, collection)).toBe(true)
+      // Pin `T` to the collection's element union explicitly; inferring it from
+      // a narrow literal value would fail the `U extends readonly T[]` constraint.
+      expect(isOneOf<Literal, typeof collection>('a', collection)).toBe(true)
+      expect(isOneOf<Literal, typeof collection>(1, collection)).toBe(true)
+      expect(isOneOf<Literal, typeof collection>(true, collection)).toBe(true)
+      expect(isOneOf<Literal, typeof collection>(null, collection)).toBe(true)
     })
 
     test('should return true when value is in collection (objects)', () => {
@@ -587,14 +589,14 @@ describe('is/collections', () => {
 
       test('should return false when property is wrong type (string vs number)', () => {
         const hasAge = isPropertyOf('age', isNumber)
-        expect(hasAge({ age: '25' as unknown })).toBe(false)
+        expect(hasAge({ age: '25' })).toBe(false)
         expect(hasAge({ age: null })).toBe(false)
         expect(hasAge({ age: undefined })).toBe(false)
       })
 
       test('should return false when property is wrong type (number vs string)', () => {
         const hasName = isPropertyOf('name', isString)
-        expect(hasName({ name: 123 as unknown })).toBe(false)
+        expect(hasName({ name: 123 })).toBe(false)
         expect(hasName({ name: null })).toBe(false)
         expect(hasName({ name: undefined })).toBe(false)
       })
@@ -732,7 +734,7 @@ describe('is/collections', () => {
           { price: 29.99, category: 'electronics' },
           { category: 'clothing' },
           {
-            price: 'free' as unknown as number | string | null,
+            price: 'free',
             category: 'promo',
           },
         ]

--- a/src/is/collections.ts
+++ b/src/is/collections.ts
@@ -49,7 +49,7 @@ export function isOneOf<T, const U extends readonly T[]>(
   value: T,
   collection: U,
 ): value is U[number] {
-  return collection.includes(value as U[number])
+  return collection.includes(value)
 }
 
 /**


### PR DESCRIPTION
Fixes the `validate` failure on #65.

oxlint 1.73 / tsgolint 0.24 tightened `no-unnecessary-type-assertion` and flagged 21 casts.

**What changed**
- Removed genuinely redundant casts (production return casts + test-input casts). Each production cast's type is already pinned by an `expectTypeOf` type test, so the contract is unchanged.
- **Restored** 3 `*OneOf` mixed-type test casts as **explicit type args** (`f<Literal, typeof collection>(…)`) — no assertion, so oxlint stays happy. These were *not* redundant: they drive generic inference of `T`; a plain removal (and even a typed local, which CFA narrows back) broke the type tests.

**Can't do**
- Base is `chore/upgrade-deps`, not `main`. Merge here first, then #65 → main goes green.

lint + typecheck + test all pass locally.