### PR TITLE
ci: automate npm releases via changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+# Never run two releases at once.
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write # push version commit + git tags, create GitHub releases
+  pull-requests: write # open/update the "Version Packages" PR
+  id-token: write # OIDC: mint short-lived npm creds via Trusted Publishing (+ provenance)
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      # If changesets exist -> opens/updates the "Version Packages" PR.
+      # If none exist but versions are unpublished -> runs publish (build via
+      # prepublishOnly), pushes git tags, creates GitHub releases.
+      - name: Create Release PR or Publish
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset version
+          publish: pnpm changeset publish
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUSKY: 0
+          # No NPM_TOKEN: auth comes from OIDC (Trusted Publishing).
+          # Requires a trusted publisher configured for this repo + workflow
+          # on npmjs.com -> narrowland -> Settings.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "scripts": {
     "prepare": "husky",
+    "prepublishOnly": "pnpm build",
     "build": "tsdown",
     "lint:check": "oxlint",
     "lint:fix": "oxlint --fix",


### PR DESCRIPTION
## What

- Add `.github/workflows/release.yml` — Changesets Action release flow.
- Add `prepublishOnly: pnpm build` — guarantees fresh `dist` before any publish (CI or manual). Repo had no build-before-publish step.

## Flow

- Feature PR carries a changeset (`pnpm changeset`) → merge to main.
- Bot opens/updates a **Version Packages** PR (bumps version + writes CHANGELOG). Accumulates multiple changesets into one PR.
- Merge that PR → CI builds, publishes to npm, pushes `vX.Y.Z` tag, cuts the GitHub release.
- **No changeset (e.g. dependabot) → nothing happens.** No release on dep bumps.

## Auth: npm Trusted Publishing (OIDC)

- No `NPM_TOKEN`, no stored secret. Short-lived creds minted per-run via OIDC (`id-token: write`). Provenance automatic.
- Fixes the `ERR_PNPM_OTP_NON_INTERACTIVE` wall — a passkey can't produce a CLI OTP, so manual publish was broken.

## Manual setup required (one-time, do BEFORE merging)

1. **npm** → narrowland → Settings → Trusted Publisher → GitHub Actions: org/user `marekh19`, repo `narrowland`, workflow `release.yml`.
2. **GitHub** → repo Settings → Actions → General → **Read and write permissions** + **Allow GitHub Actions to create and approve pull requests**.

If skipped, the first publish fails on auth (recoverable by re-running after config).

## First run

Merging this PR triggers the workflow. Local `1.8.2` > npm `1.8.1`, no pending changesets → it publishes the already-prepared **1.8.2** (the release the OTP error interrupted) and cuts its GitHub release. Reconciles the existing `v1.8.2` tag.

## Notes

- `HUSKY=0` in the job so the bot's version commit skips commitlint / lint-staged hooks.
- Tags stay `vX.Y.Z` (repo detected as `tool: root`, not `pkg@version`).
